### PR TITLE
Switch from deprecated tbb::mutex to std::mutex

### DIFF
--- a/dso/map/DeformationMap/DeformationMap.cc
+++ b/dso/map/DeformationMap/DeformationMap.cc
@@ -56,8 +56,8 @@ DeformationMap::DeformationMap(const scene_rdl2::rdl2::SceneClass& sceneClass,
     // To allow for the possibility that we may someday create image maps
     // on multiple threads, we'll protect the writes of the class statics
     // with a mutex.
-    static tbb::mutex errorMutex;
-    tbb::mutex::scoped_lock lock(errorMutex);
+    static std::mutex errorMutex;
+    std::scoped_lock lock(errorMutex);
 
     MOONRAY_START_THREADSAFE_STATIC_WRITE
 

--- a/dso/map/DirectionalMap/DirectionalMap.cc
+++ b/dso/map/DirectionalMap/DirectionalMap.cc
@@ -57,8 +57,8 @@ DirectionalMap::DirectionalMap(const SceneClass& sceneClass, const std::string& 
     // to allow for the possibility that we may someday create image maps
     // on multiple threads, we'll protect the writes of the class statics
     // with a mutex.
-    static tbb::mutex errorMutex;
-    tbb::mutex::scoped_lock lock(errorMutex);
+    static std::mutex errorMutex;
+    std::scoped_lock lock(errorMutex);
     MOONRAY_START_THREADSAFE_STATIC_WRITE
 
     sDirectionalMapData.sErrorMissingRefN = mLogEventRegistry.createEvent(scene_rdl2::logging::ERROR_LEVEL,

--- a/dso/map/GradientMap/GradientMap.cc
+++ b/dso/map/GradientMap/GradientMap.cc
@@ -114,8 +114,8 @@ GradientMap::GradientMap(const scene_rdl2::rdl2::SceneClass &sceneClass,
     // to allow for the possibility that we may someday create image maps
     // on multiple threads, we'll protect the writes of the class statics
     // with a mutex.
-    static tbb::mutex errorMutex;
-    tbb::mutex::scoped_lock lock(errorMutex);
+    static std::mutex errorMutex;
+    std::scoped_lock lock(errorMutex);
     MOONRAY_START_THREADSAFE_STATIC_WRITE
     sStaticGradientMapData.sErrorMissingReferenceData =
         mLogEventRegistry.createEvent(scene_rdl2::logging::ERROR_LEVEL,

--- a/dso/map/HairColumnMap/HairColumnMap.cc
+++ b/dso/map/HairColumnMap/HairColumnMap.cc
@@ -49,8 +49,8 @@ HairColumnMap::HairColumnMap(const SceneClass &sceneClass, const std::string &na
     // to allow for the possibility that we may someday create image maps
     // on multiple threads, we'll protect the writes of the class statics
     // with a mutex.
-    static tbb::mutex errorMutex;
-    tbb::mutex::scoped_lock lock(errorMutex);
+    static std::mutex errorMutex;
+    std::scoped_lock lock(errorMutex);
     MOONRAY_START_THREADSAFE_STATIC_WRITE
     sErrorScatterTagMissing =
         mLogEventRegistry.createEvent(scene_rdl2::logging::ERROR_LEVEL,

--- a/dso/map/NoiseMap/v2/NoiseMap_v2.cc
+++ b/dso/map/NoiseMap/v2/NoiseMap_v2.cc
@@ -67,8 +67,8 @@ NoiseMap_v2::NoiseMap_v2(SceneClass const &sceneClass,
     // to allow for the possibility that we may someday create image maps
     // on multiple threads, we'll protect the writes of the class statics
     // with a mutex.
-    static tbb::mutex errorMutex;
-    tbb::mutex::scoped_lock lock(errorMutex);
+    static std::mutex errorMutex;
+    std::scoped_lock lock(errorMutex);
     MOONRAY_START_THREADSAFE_STATIC_WRITE
     sStaticNoiseMapData.sErrorMissingReferenceData =
         mLogEventRegistry.createEvent(scene_rdl2::logging::ERROR_LEVEL,

--- a/dso/map/NoiseWorleyMap/v2/NoiseWorleyMap_v2.cc
+++ b/dso/map/NoiseWorleyMap/v2/NoiseWorleyMap_v2.cc
@@ -68,8 +68,8 @@ NoiseWorleyMap_v2::NoiseWorleyMap_v2(SceneClass const &sceneClass, std::string c
     // to allow for the possibility that we may someday create image maps
     // on multiple threads, we'll protect the writes of the class statics
     // with a mutex.
-    static tbb::mutex errorMutex;
-    tbb::mutex::scoped_lock lock(errorMutex);
+    static std::mutex errorMutex;
+    std::scoped_lock lock(errorMutex);
     MOONRAY_START_THREADSAFE_STATIC_WRITE
     sStaticNoiseWorleyMapData.sErrorMissingReferenceData =
         mLogEventRegistry.createEvent(scene_rdl2::logging::ERROR_LEVEL,

--- a/dso/map/UVTransformMap/UVTransformMap.cc
+++ b/dso/map/UVTransformMap/UVTransformMap.cc
@@ -96,8 +96,8 @@ UVTransformMap::UVTransformMap(const SceneClass& sceneClass,
     // to allow for the possibility that we may someday create image maps
     // on multiple threads, we'll protect the writes of the class statics
     // with a mutex.
-    static tbb::mutex errorMutex;
-    tbb::mutex::scoped_lock lock(errorMutex);
+    static std::mutex errorMutex;
+    std::scoped_lock lock(errorMutex);
     MOONRAY_START_THREADSAFE_STATIC_WRITE
     sStaticUVTransformMapData.sErrorMissingReferenceData =
         mLogEventRegistry.createEvent(scene_rdl2::logging::ERROR_LEVEL,

--- a/dso/material/HairLayer/HairLayerMaterial.cc
+++ b/dso/material/HairLayer/HairLayerMaterial.cc
@@ -140,8 +140,8 @@ HairLayerMaterial::HairLayerMaterial(const scene_rdl2::rdl2::SceneClass& sceneCl
     // with a mutex.
     mIspc.mStaticData = (ispc::HairLayerMaterialStaticData*)&sStaticHairLayerMaterialData;
 
-    static tbb::mutex errorMutex;
-    tbb::mutex::scoped_lock lock(errorMutex);
+    static std::mutex errorMutex;
+    std::scoped_lock lock(errorMutex);
     MOONRAY_START_THREADSAFE_STATIC_WRITE
 
     mIspc.mStaticData->sErrorMismatchedFresnelType =

--- a/lib/common/noise/Noise.cc
+++ b/lib/common/noise/Noise.cc
@@ -13,7 +13,7 @@ using namespace scene_rdl2::math;
 
 bool Noise::sNoiseIsDataInitialized = false;
 scene_rdl2::util::Random Noise::sNoiseRandom = scene_rdl2::util::Random(0xbeadceef);
-tbb::mutex Noise::sNoiseInitDataMutex;
+std::mutex Noise::sNoiseInitDataMutex;
 std::vector<int> Noise::sNoisePermutationTable;
 
 Noise::Noise(const int seed,
@@ -25,7 +25,7 @@ Noise::Noise(const int seed,
     mIspc.mTableSize = tableSize;
 
     if (useStaticTables) {
-        tbb::mutex::scoped_lock dataLock(sNoiseInitDataMutex); // Lock this part that initializes static data
+        std::scoped_lock dataLock(sNoiseInitDataMutex); // Lock this part that initializes static data
         // Only construct the static data once to share across all instances
         if (!sNoiseIsDataInitialized) {
             buildStaticTables(tableSize);

--- a/lib/common/noise/Noise.h
+++ b/lib/common/noise/Noise.h
@@ -8,9 +8,9 @@
 #pragma warning disable 1711 // Warnings about assignemnt to statically allocated data
 
 #include "Noise_ispc_stubs.h"
-#include <tbb/mutex.h>
 #include <scene_rdl2/common/math/Vec3.h>
 #include <scene_rdl2/common/math/Xform.h>
+#include <mutex>
 
 // Forward declaration
 namespace scene_rdl2 {
@@ -71,7 +71,7 @@ protected:
     // Static data
     static bool sNoiseIsDataInitialized;
     static scene_rdl2::util::Random sNoiseRandom;
-    static tbb::mutex sNoiseInitDataMutex;
+    static std::mutex sNoiseInitDataMutex;
     static std::vector<int> sNoisePermutationTable;
 
 private:

--- a/lib/common/noise/Worley.cc
+++ b/lib/common/noise/Worley.cc
@@ -227,7 +227,7 @@ collectPoints(const Worley_PointArray::iterator tmpWorleyPointsBeg,
 
 // Static data
 bool Worley::sIsWorleyDataInitialized = false;
-tbb::mutex Worley::sWorleyInitDataMutex;
+std::mutex Worley::sWorleyInitDataMutex;
 std::vector<float> Worley::sWorleyPointsX;
 std::vector<float> Worley::sWorleyPointsY;
 std::vector<float> Worley::sWorleyPointsZ;
@@ -255,7 +255,7 @@ Worley::Worley(const int seed,
     initPointProbabilities();
 
     if (useStaticTables) {
-        tbb::mutex::scoped_lock dataLock(sWorleyInitDataMutex); // Lock this part that initializes static data
+        std::scoped_lock dataLock(sWorleyInitDataMutex); // Lock this part that initializes static data
         // Only construct the static data once to share across all instances
         if (!sIsWorleyDataInitialized) {
             buildStaticPointTables(addNormals, tableSize);

--- a/lib/common/noise/Worley.h
+++ b/lib/common/noise/Worley.h
@@ -184,7 +184,7 @@ private:
 
     // Static data
     static bool sIsWorleyDataInitialized;
-    static tbb::mutex sWorleyInitDataMutex;
+    static std::mutex sWorleyInitDataMutex;
 
     static std::vector<float> sWorleyPointsX;
     static std::vector<float> sWorleyPointsY;

--- a/lib/map/projection/ProjectionUtil.cc
+++ b/lib/map/projection/ProjectionUtil.cc
@@ -24,8 +24,8 @@ initLogEvents(ispc::PROJECTION_StaticData& staticData,
     // to allow for the possibility that we may someday create image maps
     // on multiple threads, we'll protect the writes of the class statics
     // with a mutex.
-    static tbb::mutex errorMutex;
-    tbb::mutex::scoped_lock lock(errorMutex);
+    static std::mutex errorMutex;
+    std::scoped_lock lock(errorMutex);
     MOONRAY_START_THREADSAFE_STATIC_WRITE
 
     staticData.sErrorMissingProjector = logEventRegistry.createEvent(scene_rdl2::logging::ERROR_LEVEL,

--- a/lib/material/dwabase/DwaBaseLayerable.cc
+++ b/lib/material/dwabase/DwaBaseLayerable.cc
@@ -53,8 +53,8 @@ DwaBaseLayerable::registerShadeTimeEventMessages()
    // To allow for the possibility that we may someday create materials
    // on multiple threads, we'll protect the writes of the class statics
    // with a mutex.
-   static tbb::mutex errorMutex;
-   tbb::mutex::scoped_lock lock(errorMutex);
+   static std::mutex errorMutex;
+   std::scoped_lock lock(errorMutex);
    MOONRAY_START_THREADSAFE_STATIC_WRITE
 
    sEventMessages.sErrorNoRefN =


### PR DESCRIPTION
# ReleaseNote
Compatibility (major, minor, patch, build): build
Jira ticket: na
Release Notes Comment:

Special Notes: Changes away from tbb::mutex to the std::mutex as it has been deprecated and removed in tbb 2021+

Look or Scene Setup Change: No
